### PR TITLE
Allow for multiple rollout versions

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -50,7 +50,11 @@ func (canaryHandler *CanaryHandler) Handle(input string) string {
 		log.Printf("handler: assignment is out of [0.0,1.0) range: %v\n", assignment)
 		return fmt.Sprintf(format, rand.Float64(), value)
 	}
-	rollout := canaryHandler.rollout.Get()
+	rolloutP := canaryHandler.rollout.Get("canary")
+	rollout := 0.0
+	if rolloutP != nil {
+		rollout = *rolloutP
+	}
 	if rollout < 0 || rollout > 1 {
 		canaryHandler.monitor.RecordHandling(value, fmt.Errorf("rollout out of range"))
 		log.Printf("handler: rollout is out of [0.0,1.0] range\n")

--- a/rollout.go
+++ b/rollout.go
@@ -14,10 +14,18 @@ import (
 // Rollout is an interface implemented by a value that can provide a rollout
 // percentage as a decimal in the range [0.0,1.0]
 type Rollout interface {
-	// Get provides the current rollout value.
+	// Get provides the current rollout value for a specific version.
+	// nil will be returned if the value cannot be provided (non-existent
+	// or stale).
 	// Note that it is possible for the value to be outside of the
 	// acceptable [0.0,1.0] range - this should be checked by the caller.
-	Get() float64
+	Get(string) *float64
+}
+
+type version struct {
+	lastUpdated time.Time
+	isUnhealthy bool
+	percentage  float64
 }
 
 // A DynamoDBRollout represents a rollout that is continuously fetched from
@@ -29,10 +37,46 @@ type Rollout interface {
 // If enough calls to DynamoDB fail, the rollout value will drop to 0 to
 // minimize possible damange (i.e. the inability to rollback a canary).
 type DynamoDBRollout struct {
-	db      *dynamodb.DynamoDB
-	table   string
-	mutex   *sync.RWMutex
-	rollout float64
+	db       *dynamodb.DynamoDB
+	table    string
+	mutex    *sync.RWMutex
+	versions map[string]version
+}
+
+func (r *DynamoDBRollout) update(unhealthy time.Duration, updates map[string]float64) {
+	if updates == nil {
+		updates = make(map[string]float64)
+	}
+	r.mutex.Lock()
+	// update existing entries
+	for key, val := range r.versions {
+		newPercentage, ok := updates[key]
+		if !ok {
+			if time.Since(val.lastUpdated) > unhealthy {
+				if !val.isUnhealthy && val.percentage > 0 {
+					log.Printf("rollout: \"%v\" contains stale data", key)
+				}
+				val.percentage = 0
+				val.isUnhealthy = true
+			}
+		} else {
+			val.lastUpdated = time.Now()
+			val.isUnhealthy = false
+			val.percentage = newPercentage
+		}
+	}
+	// add missing entries
+	for key, val := range updates {
+		_, ok := r.versions[key]
+		if !ok {
+			r.versions[key] = version{
+				lastUpdated: time.Now(),
+				isUnhealthy: false,
+				percentage:  val,
+			}
+		}
+	}
+	r.mutex.Unlock()
 }
 
 // NewDynamoDBRollout creates a new DynamoDBRollout and begins eternally
@@ -45,67 +89,92 @@ type DynamoDBRollout struct {
 func NewDynamoDBRollout(monitor Monitor, db *dynamodb.DynamoDB, table string, application string, delay time.Duration, unhealthy time.Duration) (*DynamoDBRollout, error) {
 	const hashField string = "application"
 	const rangeField string = "version"
-	const rangeKey string = "canary"
 	const rolloutField string = "rollout"
+	// []strings are not constants
+	rangeKeys := []string{
+		"canary",
+	}
 
 	if db == nil {
 		return nil, fmt.Errorf("dynamo.DynamoDB argument is nil")
 	}
 	dynamodbRollout := &DynamoDBRollout{
-		db:      db,
-		table:   table,
-		mutex:   &sync.RWMutex{},
-		rollout: 0,
+		db:       db,
+		table:    table,
+		mutex:    &sync.RWMutex{},
+		versions: make(map[string]version),
 	}
-
-	getItemInput := &dynamodb.GetItemInput{
-		TableName: aws.String(table),
-		Key: map[string]*dynamodb.AttributeValue{
+	var keys []map[string]*dynamodb.AttributeValue
+	for _, key := range rangeKeys {
+		keys = append(keys, map[string]*dynamodb.AttributeValue{
 			hashField:  {S: aws.String(application)},
-			rangeField: {S: aws.String(rangeKey)},
+			rangeField: {S: aws.String(key)},
+		})
+	}
+	batchGetItemInput := &dynamodb.BatchGetItemInput{
+		RequestItems: map[string]*dynamodb.KeysAndAttributes{
+			table: &dynamodb.KeysAndAttributes{
+				ProjectionExpression: aws.String(fmt.Sprintf("%v, %v", rangeField, rolloutField)),
+				ConsistentRead:       aws.Bool(true),
+				Keys:                 keys,
+			},
 		},
-		ProjectionExpression: aws.String(rolloutField),
-		ConsistentRead:       aws.Bool(true),
 	}
-	loadRollout := func() (float64, error) {
-		getItemOutput, err := db.GetItem(getItemInput)
+	loadRollouts := func() map[string]float64 {
+		batchGetItemOutput, err := db.BatchGetItem(batchGetItemInput)
 		if err != nil {
-			return 0, fmt.Errorf("could not fetch rollout value: %v\n", err)
+			log.Printf("could not fetch rollout values: %v", err)
+			return nil
 		}
-		percentageRaw := getItemOutput.Item["rollout"]
-		if percentageRaw == nil {
-			return 0, fmt.Errorf("could not find \"rollout\" key in response\n")
+		tableItems, ok := batchGetItemOutput.Responses[table]
+		if !ok {
+			log.Printf("could not find rollout values in response")
+			return nil
 		}
-		percentageString := percentageRaw.N
-		if percentageString == nil {
-			return 0, fmt.Errorf("rollout value is not stored as a number type\n")
+		results := make(map[string]float64)
+		loadRollout := func(item map[string]*dynamodb.AttributeValue) error {
+			nameRaw, ok := item[rangeField]
+			if !ok {
+				return fmt.Errorf("could not find \"%s\" key in response item", rangeField)
+			}
+			name := nameRaw.S
+			if name == nil {
+				return fmt.Errorf("release name is not stored as a string type")
+			}
+			if *name == "" {
+				return fmt.Errorf("release name is empty string")
+			}
+			percentageRaw := item[rolloutField]
+			if percentageRaw == nil {
+				return fmt.Errorf("could not find \"%s\" key in response", rolloutField)
+			}
+			percentageString := percentageRaw.N
+			if percentageString == nil {
+				return fmt.Errorf("rollout value is not stored as a number type")
+			}
+			percentage, err := strconv.ParseFloat(*percentageString, 64)
+			if err != nil {
+				return fmt.Errorf("could not parse rollout value as a number: %v", err)
+			}
+			if percentage < 0 || percentage > 1 {
+				return fmt.Errorf("rollout value is out of [0.0,1.0] range")
+			}
+			results[*name] = percentage
+			return nil
 		}
-		percentage, err := strconv.ParseFloat(*percentageString, 64)
-		if err != nil {
-			return 0, fmt.Errorf("could not parse rollout value as a number: %v\n", err)
-		}
-		if percentage < 0 || percentage > 1 {
-			return 0, fmt.Errorf("rollout value is out of [0.0,1.0] range")
-		}
-		return percentage, nil
-	}
-	go func() {
-		lastHealthy := time.Now()
-		for {
-			percentage, err := loadRollout()
+		for _, item := range tableItems {
+			err := loadRollout(item)
 			monitor.RecordRolloutUpdate(err)
 			if err != nil {
-				log.Printf("rollout: %v\n", err)
-				if time.Since(lastHealthy) > unhealthy {
-					log.Printf("rollout: unhealthy for %v (rollout dropped to 0.0)\n", lastHealthy)
-					percentage = 0
-				}
-			} else {
-				lastHealthy = time.Now()
+				log.Printf("rollout: error during update: %v", err)
 			}
-			dynamodbRollout.mutex.Lock()
-			dynamodbRollout.rollout = percentage
-			dynamodbRollout.mutex.Unlock()
+		}
+		return results
+	}
+	go func() {
+		for {
+			updates := loadRollouts()
+			dynamodbRollout.update(unhealthy, updates)
 			time.Sleep(delay)
 		}
 	}()
@@ -114,10 +183,18 @@ func NewDynamoDBRollout(monitor Monitor, db *dynamodb.DynamoDB, table string, ap
 
 // Get provides the most recently read rollout value from DynamoDB.
 // The return value may be outside of the [0.0,1.0] range.
-func (dynamodbRollout *DynamoDBRollout) Get() float64 {
-	dynamodbRollout.mutex.RLock()
-	defer dynamodbRollout.mutex.RUnlock()
-	return dynamodbRollout.rollout
+func (r *DynamoDBRollout) Get(name string) *float64 {
+	r.mutex.RLock()
+	defer r.mutex.RUnlock()
+	version, ok := r.versions[name]
+	if !ok {
+		log.Printf("rollout: request for nonexistent version: \"%v\"", name)
+		return nil
+	}
+	if version.isUnhealthy {
+		return nil
+	}
+	return &version.percentage
 }
 
 // A ConstantRollout represents a rollout that will always have the same value.
@@ -135,6 +212,6 @@ func NewConstantRollout(value float64) *ConstantRollout {
 
 // Get provides the rollout value that this value was created with.
 // The return value may be outside of the [0.0,1.0] range.
-func (constantRollout *ConstantRollout) Get() float64 {
-	return constantRollout.value
+func (constantRollout *ConstantRollout) Get(_ string) *float64 {
+	return &constantRollout.value
 }

--- a/server_test.go
+++ b/server_test.go
@@ -782,7 +782,7 @@ func TestUnixServingLargeInput(t *testing.T) {
 		t.Fatalf("could not write long text to server: %v", err)
 	}
 	if count != len(input) {
-		t.Fatalf("only wrote %v out of %v bytes to server")
+		t.Fatalf("wrote %v out of %v bytes to server", count, len(input))
 	}
 	response, err := bufio.NewReader(connection).ReadString('\n')
 	if err != nil {


### PR DESCRIPTION
This also inverts control, making callers to rollout.Get() decide how
to handle stale data (more flexibility this way).
